### PR TITLE
Remove unused preload script

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -43,7 +43,6 @@ function createMainWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
-      preload: path.join(__dirname, 'preload.js'),
       partition: 'persist:chatgpt'
     }
   });

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,1 +1,0 @@
-// Reserved for future needs like script injection or secured API exposure


### PR DESCRIPTION
## Summary
- drop unused `preload.js`
- remove preload configuration from `BrowserWindow`

## Testing
- `npx electron --version` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687bd5b796ac832f8a7bba8d842a2d11