### PR TITLE
Add basic tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "electron .",
     "package": "electron-packager . chatgpt-webclient --platform=linux --arch=x64 --icon=assets/icon.png --overwrite",
-    "deb": "npm run package && electron-installer-debian --src chatgpt-webclient-linux-x64/ --dest dist/ --arch amd64"
+    "deb": "npm run package && electron-installer-debian --src chatgpt-webclient-linux-x64/ --dest dist/ --arch amd64",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",
@@ -42,8 +43,10 @@
       "target": "dmg"
     },
     "linux": {
-      "target": ["deb", "AppImage"]
+      "target": [
+        "deb",
+        "AppImage"
+      ]
     }
   }
-
 }

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('package.json contains required scripts', async () => {
+  const pkgPath = path.join(__dirname, '..', 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  assert.ok(pkg.scripts && pkg.scripts.start, 'start script missing');
+  assert.ok(pkg.scripts && pkg.scripts.deb, 'deb script missing');
+});
+
+test('settings.html has expected elements', async () => {
+  const htmlPath = path.join(__dirname, '..', 'src', 'settings.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  assert.ok(/id="alwaysOnTop"/.test(html), 'alwaysOnTop checkbox missing');
+  assert.ok(/id="minimizeToTray"/.test(html), 'minimizeToTray checkbox missing');
+  assert.ok(/id="autoLaunch"/.test(html), 'autoLaunch checkbox missing');
+  assert.ok(/id="shortcutPreset"/.test(html), 'shortcutPreset select missing');
+});


### PR DESCRIPTION
## Summary
- add a simple test suite using Node's builtin `test` module
- ensure required scripts are present in `package.json`
- verify key elements exist in `settings.html`
- configure `npm test` to run `node --test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bd3ca7a94832f9cb62ec2ac7d5e03