### PR TITLE
Add build scripts and docs for Windows and macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ npm run deb
 npm run build:flatpak
 ```
 
+### Build on Windows
+
+```bash
+npm run dist -- --win
+```
+
+Produces an installer in the `dist/` directory. Building Windows packages
+requires either a Windows host or Wine installed on Linux.
+
+### Build on macOS
+
+```bash
+npm run dist -- --mac
+```
+
+DMG creation requires running on macOS.
+
 Output is in `dist/`.
 
 ---

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "package": "electron-packager . chatgpt-webclient --platform=linux --arch=x64 --icon=assets/icon.png --overwrite",
     "deb": "npm run package && electron-installer-debian --src chatgpt-webclient-linux-x64/ --dest dist/ --arch amd64",
     "dist": "electron-builder",
+    "dist:win": "electron-builder --win",
+    "dist:mac": "electron-builder --mac",
     "test": "node --test",
     "build:flatpak": "electron-builder --linux --target=flatpak"
   },


### PR DESCRIPTION
## Summary
- provide `dist:win` and `dist:mac` npm scripts
- document building on Windows and macOS in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bd96f9288832f90e421627c4d70eb